### PR TITLE
fix-unwrap-key-error #12

### DIFF
--- a/iloot.py
+++ b/iloot.py
@@ -411,7 +411,7 @@ class MobileBackupClient(object):
 
         print "Got OTA Keybag"
 
-        self.kb = Keybag(keys.Key[1].KeyData)
+        self.kb = Keybag(keys.Key[-1].KeyData)
         if not self.kb.unlockBackupKeybagWithPasscode(keys.Key[0].KeyData):
             print "Unable to unlock OTA keybag !"
             return


### PR DESCRIPTION
Sometimes ICloud sends keybag with 3 and more keys. I tried to use last key from keybag and it helped me.