### PR TITLE
Repeated MBSBackup/ MBSSnapshots

### DIFF
--- a/icloud.proto
+++ b/icloud.proto
@@ -8,7 +8,7 @@ message MBSAccount {
 message MBSBackup {
     optional bytes backupUDID = 1;
     optional uint64 QuotaUsed = 2;
-    optional MBSSnapshot Snapshot = 3;
+    repeated MBSSnapshot Snapshot = 3;
     optional MBSBackupAttributes Attributes = 4;
     optional uint64 KeysLastModified = 5;
 }


### PR DESCRIPTION
Now decodes all available MBSSnapshots.

This will allow you to retrieve all the available MBSSnapshots rather than relying on 1, latest -1, latest. The first snapshot doesn't always reside at 1. Also 4 snapshots may be present, with the last incomplete.

I've also opened an issue discussing this amongst other suggestions: https://github.com/hackappcom/iloot/issues/58
- This change in isolation will break iloot, you'll need to rework the corresponding access code to factor in the change to an array.
