### PR TITLE
Update example to include --threads command-line arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Example
 
 ```bash
 $ python iloot.py -h
-usage: iloot [-h] [--output OUTPUT] [--combined] [--snapshot SNAPSHOT]
-             [--itunes-style] [--item-types ITEM_TYPES [ITEM_TYPES ...]]
-             [--domain DOMAIN]
+usage: iloot [-h] [--threads THREADS] [--output OUTPUT] [--combined]
+             [--snapshot SNAPSHOT] [--itunes-style]
+             [--item-types ITEM_TYPES [ITEM_TYPES ...]] [--domain DOMAIN]
              apple_id password
 
 positional arguments:
@@ -34,6 +34,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            Show this help message and exit.
+  --threads THREADS     Download thread pool size
   --output OUTPUT, -o OUTPUT
                         Output directory.
   --combined            Do not separate each snapshot into its own folder


### PR DESCRIPTION
The `README` includes an example of running the program and printing the documentation. The `--threads` command line argument is missing.

I ran `python iloot.py -h` in a terminal and copied the parts relating to `--threads` to the `README` so that the `README` is up-to-date with the tool.