### PR TITLE
Add option --keep-existing that skips already downloaded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Example
 
 ```bash
 $ python iloot.py -h
-usage: iloot [-h] [--output OUTPUT] [--combined] [--snapshot SNAPSHOT]
-             [--itunes-style] [--item-types ITEM_TYPES [ITEM_TYPES ...]]
-             [--domain DOMAIN]
+usage: iloot [-h] [--threads THREADS] [--output OUTPUT] [--combined]
+             [--snapshot SNAPSHOT] [--itunes-style]
+             [--item-types ITEM_TYPES [ITEM_TYPES ...]] [--domain DOMAIN]
              apple_id password
 
 positional arguments:
@@ -34,6 +34,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            Show this help message and exit.
+  --threads THREADS     Download thread pool size
   --output OUTPUT, -o OUTPUT
                         Output directory.
   --combined            Do not separate each snapshot into its own folder

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ python iloot.py -h
 usage: iloot [-h] [--threads THREADS] [--output OUTPUT] [--combined]
              [--snapshot SNAPSHOT] [--itunes-style]
              [--item-types ITEM_TYPES [ITEM_TYPES ...]] [--domain DOMAIN]
+             [--keep-existing]
              apple_id password
 
 positional arguments:
@@ -52,6 +53,10 @@ optional arguments:
   --domain DOMAIN, -d DOMAIN
                         Limit files to those within a specific application
                         domain
+  --keep-existing       Do not download files that has already been downloaded
+                        in a previous run. Skip files that already exist
+                        locally and that has the same file size locally as in
+                        the backup.
 ```
 
 By default, the tool will download everything in a backup. If you'd only like to download a specific item type (such as all SMSs), just specify the `--item-types` argument. For instance:


### PR DESCRIPTION
When the option is set, any files that already exist locally are skipped and not downloaded again. Files that exist locally but where the file size differs from the backup will be downloaded.

This can be used to resume a failed or interrupted backup. Personally, I have been using this to get around issue https://github.com/hackappcom/iloot/issues/35.

I hope this can be of use to anyone. Tested on Linux.